### PR TITLE
New crash behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,9 @@ The reset button makes it possible to test crash handling code. Press the
 button to simulate a crash. Your algorithm should periodically check if the
 button was pressed via `wasReset`. If so, your algorithm should reset any
 internal state and then call `ackReset` to send the robot back to the beginning
-of the maze.
+of the maze. After a crash, the commands `moveForward`, `turnRight`, and
+`turnLeft` will be ignored (the simulator will return "crash" and the mouse will
+not move) until `ackReset` is called.
 
 
 ## Maze Files

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -917,6 +917,7 @@ void Window::onResetButtonPressed() {
     m_resetButton->setEnabled(false);
     m_resetButton->setText("Waiting");
     m_wasReset = true;
+    disabledMovement = true;
 }
 
 QStringList Window::processText(QString text, QStringList* buffer) {

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -1112,7 +1112,7 @@ QString Window::executeCommand(QString command) {
         return boolToString(wallLeft());
     }
     else if (function == "moveForward") {
-        if (disabledMovement) return Window::CRASH;
+        if (disabledMovement) return CRASH;
         bool success;
         if (tokens.size() == 2) {
             int distance = tokens.at(1).toInt();
@@ -1128,12 +1128,12 @@ QString Window::executeCommand(QString command) {
         return success ? "" : CRASH;
     }
     else if (function == "turnRight") {
-        if (disabledMovement) return Window::CRASH;
+        if (disabledMovement) return CRASH;
         turnRight();
         return "";
     }
     else if (function == "turnLeft") {
-        if (disabledMovement) return Window::CRASH;
+        if (disabledMovement) return CRASH;
         turnLeft();
         return "";
     }

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -734,6 +734,9 @@ void Window::startRun() {
     m_map->setView(m_view);
     m_map->setMouseGraphic(m_mouseGraphic);
 
+    // Enable movement
+    disabledMovement = false;
+
     // Instantiate a new process
     QProcess* process = new QProcess();
 
@@ -1109,14 +1112,28 @@ QString Window::executeCommand(QString command) {
         return boolToString(wallLeft());
     }
     else if (function == "moveForward") {
-        bool success = moveForward();
+        if (disabledMovement) return Window::CRASH;
+        bool success;
+        if (tokens.size() == 2) {
+            int distance = tokens.at(1).toInt();
+            success = moveForward(distance);
+        }
+        else {
+            success = moveForward();
+        }
+        // disable movement commands after a crash
+        if (!success) {
+            disabledMovement = true;
+        }
         return success ? "" : CRASH;
     }
     else if (function == "turnRight") {
+        if (disabledMovement) return Window::CRASH;
         turnRight();
         return "";
     }
     else if (function == "turnLeft") {
+        if (disabledMovement) return Window::CRASH;
         turnLeft();
         return "";
     }
@@ -1125,6 +1142,7 @@ QString Window::executeCommand(QString command) {
     }
     else if (function == "ackReset") {
         ackReset();
+        disabledMovement = false;
         return ACK;
     }
     else {

--- a/src/Window.h
+++ b/src/Window.h
@@ -169,6 +169,7 @@ private:
     double m_movementProgress;
     double m_movementStepSize;
     QSlider* m_speedSlider;
+    bool disabledMovement = false;
 
     double progressRequired(Movement movement);
     void updateMouseProgress(double progress);


### PR DESCRIPTION
After a crash, the mouse will be disabled. This means it will not move or turn until the ackReset command is sent. This PR must come after my previous two PRs, so the code will not compile properly if these changes are incorporated without those changes.