### PR TITLE
Add API to get stats from simulator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ void clearAllColor();
 void setText(int x, int y, const std::string& text);
 void clearText(int x, int y);
 void clearAllText();
+float getStat(char* stat);
 
 bool wasReset();
 void ackReset();
@@ -208,6 +209,23 @@ void ackReset();
 * **Args:** None
 * **Action:** Clear the text of all cells
 * **Response:** None
+
+#### `getStat`
+* **Args:**
+  * `stat`: A string representing the stat to query. Available stats are:
+    * `total-distance (int)`
+    * `total-turns (int)`
+    * `best-run-distance (int)`
+    * `best-run-turns (int)`
+    * `current-run-distance (int)`
+    * `current-run-turns (int)`
+    * `total-effective-distance (float)`
+    * `best-run-effective-distance (float)`
+    * `current-run-effective-distance (float)`
+    * `score (float)`
+* **Action:** None
+* **Response:** The value of the stat, or `-1` if no value exists yet. The value will either be a float or integer, according to the types listed above.
+
 
 #### `wasReset`
 * **Args:** None

--- a/src/Stats.cpp
+++ b/src/Stats.cpp
@@ -127,4 +127,32 @@ void Stats::penalizeForReset() {
     penalty = 15;
 }
 
+bool Stats::isInteger(StatsEnum stat) {
+    // Returns true if the stat represents an integer value
+    return (stat == StatsEnum::TOTAL_DISTANCE
+            || stat == StatsEnum::TOTAL_TURNS
+            || stat == StatsEnum::BEST_RUN_DISTANCE
+            || stat == StatsEnum::BEST_RUN_TURNS
+            || stat == StatsEnum::CURRENT_RUN_DISTANCE
+            || stat == StatsEnum::CURRENT_RUN_TURNS
+            );
+}
+
+QString Stats::getStat(StatsEnum stat) {
+    QString statText = textField[stat]->text();
+    // Cast the stat to an integer if it's supposed to be an integer
+    if (isInteger(stat)) {
+        bool converted;
+        statText = QString::number(statText.toInt(&converted));
+        if (converted) {
+            return statText;
+        }
+        else {
+            // Return empty string if integer conversion failed
+            return "";
+        }
+    }
+    return statText;
+}
+
 }

--- a/src/Stats.h
+++ b/src/Stats.h
@@ -30,6 +30,7 @@ public:
     void finishRun(); // A run finishes when the mouse enters the goal.
     void endUnfinishedRun(); // A run ends unfinished when the mouse returns to the start tile
     void penalizeForReset(); // Applies a penalty when the mouse resets to the start tile
+    QString getStat(StatsEnum stat); // Return the current value of the requested stat
 
 private:
     QMap<StatsEnum, float> statValues;
@@ -42,6 +43,7 @@ private:
     void setStat(StatsEnum stat, float value);
     static float getEffectiveDistance(int distance);
     void reset(StatsEnum stat);
+    bool isInteger(StatsEnum stat);
 };
 
 }

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -1117,7 +1117,8 @@ QString Window::executeCommand(QString command) {
         return INVALID;
     }
     QString function = tokens.at(0);
-    if (tokens.size() == 2 && function != "moveForward") {
+    if (tokens.size() == 2 &&
+            !(function == "moveForward" || function == "getStat")) {
         return INVALID;
     }
     if (function == "mazeWidth") {
@@ -1157,6 +1158,53 @@ QString Window::executeCommand(QString command) {
     else if (function == "ackReset") {
         ackReset();
         return ACK;
+    }
+    else if (function == "getStat") {
+        if (tokens.size() != 2) {
+            return INVALID;
+        }
+        QString stat = tokens.at(1);
+        // Convert stat to a StatsEnum
+        StatsEnum statsEnum;
+        if (stat == "total-distance") {
+            statsEnum = StatsEnum::TOTAL_DISTANCE;
+        }
+        else if (stat == "total-turns") {
+            statsEnum = StatsEnum::TOTAL_TURNS;
+        }
+        else if (stat == "best-run-distance") {
+            statsEnum = StatsEnum::BEST_RUN_DISTANCE;
+        }
+        else if (stat == "best-run-turns") {
+            statsEnum = StatsEnum::BEST_RUN_TURNS;
+        }
+        else if (stat == "current-run-distance") {
+            statsEnum = StatsEnum::CURRENT_RUN_DISTANCE;
+        }
+        else if (stat == "current-run-turns") {
+            statsEnum = StatsEnum::CURRENT_RUN_TURNS;
+        }
+        else if (stat == "total-effective-distance") {
+            statsEnum = StatsEnum::TOTAL_EFFECTIVE_DISTANCE;
+        }
+        else if (stat == "best-run-effective-distance") {
+            statsEnum = StatsEnum::BEST_RUN_EFFECTIVE_DISTANCE;
+        }
+        else if (stat == "current-run-effective-distance") {
+            statsEnum = StatsEnum::CURRENT_RUN_EFFECTIVE_DISTANCE;
+        }
+        else if (stat == "score") {
+            statsEnum = StatsEnum::SCORE;
+        }
+        else {
+            return INVALID;
+        }
+        QString statValue = stats->getStat(statsEnum);
+        if (statValue == "") {
+            // Cannot return an empty string. Return -1 to indicate empty field.
+            return "-1";
+        }
+        return statValue;
     }
     else {
         return INVALID;


### PR DESCRIPTION
This change will allow the algorithm or proxy to get the value of any stat from the simulator. I decided to expose all the stats, which will allow the proxy to print out a detailed log at the end of the run if desired. However, if you would rather not expose all the stats, this could be changed to only expose the total effective distance + total turns, which is what will be used to determine when the mouse exceeds its move limit. If the text box is empty (which is the case for "best run" stats before a run is finished), the string `"-1"` will be returned, but I could change it to something like `"empty"` if that makes more sense.